### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "octmon.flutter_des"
     compileSdkVersion 30
 
     compileOptions {
@@ -31,5 +32,12 @@ android {
 
     defaultConfig {
         minSdkVersion 16
+    }
+}
+
+configurations.all {
+    resolutionStrategy {
+        force 'androidx.core:core:1.6.0'
+        force 'androidx.core:core-ktx:1.6.0'
     }
 }


### PR DESCRIPTION
fix for building with Flutter 3.24.3 error namespace and flutter_des:verifyReleaseResources